### PR TITLE
Specify a minimum Moose version explicitly

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,9 @@ copyright_year   = 2012
 ;tweet = 1
 autoprereqs_skip = ^(funcs|TestClass.*|TestRole.*)$
 
+[Prereqs]
+Moose = 2.0
+
 [RemovePrereqs]
 ; this was excluded from cpan indexing around 2.0002, so depending on it leads
 ; to predictably fun mouse-in-a-wheel debugging sessions :\


### PR DESCRIPTION
Not quite sure the exact min version, but Moose 1.24 does not work.
