### PR TITLE
Fix improper use of tb->skip

### DIFF
--- a/lib/Test/Moose/More.pm
+++ b/lib/Test/Moose/More.pm
@@ -954,7 +954,7 @@ sub _class_attribute_options_ok {
 
     $check->($_) for grep { any(@check_opts) eq $_ } sort keys %opts;
 
-    do { $tb->skip("cannot test '$_' options yet", 1); delete $opts{$_} }
+    do { $tb->skip("cannot test '$_' options yet"); delete $opts{$_} }
         for grep { exists $opts{$_} } @unhandled_opts;
 
     if (exists $opts{init_arg}) {


### PR DESCRIPTION
Currently Test::Builder::skip() takes a reason why you are skipping, and nothing else. You call $tb->skip($why, 1). A real second argument (test name) is probably coming, which causes your tests to break.

This PR fixes the issue.